### PR TITLE
feat: implement changes for initial Credly integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 pr_*.json
 winners*.json
+winners*.csv
 *email-rendered*.html
 
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -21,8 +21,8 @@ RUN pip install pybuilder \
     && pyb install_dependencies --no-venvs \
     && pyb install --no-venvs --verbose
 
-FROM python:3-alpine
+FROM python:3-slim
 WORKDIR /badger
 COPY --from=build-image /build/target/dist/badger-*/dist/badger-*.tar.gz .
 RUN pip install badger-*.tar.gz \
-    && apk add --update --no-cache curl
+    && apt-get update && apt-get install -y curl && apt-get clean

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,7 @@ pipeline {
                             sh badgerCommand
                             winners = readJSON(file: 'winners.json')
                             archiveArtifacts allowEmptyArchive: true, artifacts: 'badger-edgexfoundry.log'
+                            archiveArtifacts allowEmptyArchive: true, artifacts: '*.csv'
                         }
                     }
                 }
@@ -191,9 +192,8 @@ def sendWinnerEmails(winners) {
         badgeDetails = winners.badge_details[badgeKey]
         
         winnerList.each { winner ->
-            winner.first_name = winner.name.split(' ')[0]
+            winner.first_name = winner.name != 'None' ? winner.name.split(' ')[0] : winner.author
             winner.image_url = badgeDetails.image_url
-            winner.download_url = badgeDetails.download_url
 
             def finalWinners = './winners-final.json'
             writeJSON(json: winner, file: finalWinners)
@@ -230,7 +230,8 @@ def sendAdminEmail(winners, recipients) {
         }
     }
     adminEmailBody += "</ul>"
-    adminEmailBody += "<p>For further info please email the DevOps WG email or visit the <a href=\"https://edgexfoundry.slack.com/archives/CE46S51DX\" target=\"_blank\">#devops</a> slack channel</p>"
+    adminEmailBody += "<p>To download the Winner CSV <a href=\"${env.JENKINS_URL}/job/edgexfoundry/job/edgex-dev-badge/job/main/lastSuccessfulBuild/artifact/winners.csv\">Click here</a></p>"
+    adminEmailBody += "<p>For further info/help please email the DevOps WG email or visit the <a href=\"https://edgexfoundry.slack.com/archives/CE46S51DX\" target=\"_blank\">#devops</a> slack channel</p>"
 
     if(env.DRY_RUN == 'false') {
         mail body: adminEmailBody, subject: "[${winnerCount}] EdgeX Badge Winners Awarded", to: recipients, mimeType: 'text/html'

--- a/README.md
+++ b/README.md
@@ -66,18 +66,21 @@ Jenkins automation combines the badger cli and email Jenkins' email capabilities
                                    `>>>
                   I badge so you don't have to.
     
-usage: badger [-h] [--org ORG] [--badges BADGES] [--winners WINNERS] [--lookback LOOKBACK] [--no-lookback] [--execute]
+usage: badger [-h] [--org ORG] [--badges BADGES] [--winners-json WINNERS_JSON] [--winners-csv WINNERS_CSV] [--lookback LOOKBACK] [--no-lookback] [--execute]
 
 Rules based GitHub badge scanner
 
 optional arguments:
-  -h, --help           show this help message and exit
-  --org ORG            The organization to lookup (default: edgexfoundry)
-  --badges BADGES      badge file to lookup rules (default: ./badges.yml)
-  --winners WINNERS    File to write winners json to (default: ./winners.json)
-  --lookback LOOKBACK  Lookback window for PRs (default: 30)
-  --no-lookback        Do not use lookback window and search all PRs (default: False)
-  --execute            execute processing - not setting is same as running in NOOP mode (default: False)
+  -h, --help            show this help message and exit
+  --org ORG             The organization to lookup (default: edgexfoundry)
+  --badges BADGES       badge file to lookup rules (default: ./badges.yml)
+  --winners-json WINNERS_JSON
+                        File to write winners json to (default: ./winners.json)
+  --winners-csv WINNERS_CSV
+                        File to write winners json to (default: ./winners.csv)
+  --lookback LOOKBACK   Lookback window for PRs (default: 30)
+  --no-lookback         Do not use lookback window and search all PRs (default: False)
+  --execute             execute processing - not setting is same as running in NOOP mode (default: False)
 ```
 
 ## Reference
@@ -126,7 +129,7 @@ $ badger --org edgexfoundry --lookback 365 && cat ./winners.json
 More complex example to query the `edgexfoundry` org for ALL PR's ever closed and use a different badge yaml file and write the winners to a different directory.
 
 ```bash
-$ badger --org edgexfoundry --no-lookback --badges super-badges.yml --winners super-winners.json && cat ./super-winners.json
+$ badger --org edgexfoundry --no-lookback --badges super-badges.yml --winners-json super-winners.json && cat ./super-winners.json
 ...
 {"count": 1, "badge_details": {"bug_hunter": {"display": "Bug Hunter",...
 ```

--- a/badges.yml
+++ b/badges.yml
@@ -11,7 +11,7 @@ badges:
     enabled: true
     display: Bug Hunter
     image_url: https://raw.githubusercontent.com/edgexfoundry/edgex-dev-badge/main/badges/edgexfoundry/images/bug_hunter/EdgeEx_BugHunter_v2-01.png
-    download_url: https://raw.githubusercontent.com/edgexfoundry/edgex-dev-badge/main/badges/edgexfoundry/images/bug_hunter/EdgeEx_BugHunter_v2-01.png
+    credly_id: 740e9daa-ef58-43ce-97b0-54bd99bbe164
     description: Squash 2 bugs and recieve this badge. You will be accailmed as one of the chosen, a true exterminator.
     trigger:
       merged_pr: 2
@@ -19,10 +19,10 @@ badges:
       labels:
         - bug
   - id: first_time_committer
-    enabled: false
-    display: First Time Contributor
+    enabled: true
+    display: First Time Committer
     image_url: https://raw.githubusercontent.com/edgexfoundry/edgex-dev-badge/main/badges/edgexfoundry/images/first_time_committer/EdgeEx_firsttimecontributor.png
-    download_url: https://raw.githubusercontent.com/edgexfoundry/edgex-dev-badge/main/badges/edgexfoundry/images/first_time_committer/EdgeEx_firsttimecontributor.png
+    credly_id: a269a9ae-156e-4b03-bf8a-e78b30039599
     description: You did it! You first merged PR for the EdgeX community! Now go talk to Jim!
     trigger:
       merged_pr: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 progress1bar
 pyfiglet
 ansicolors
+pandas

--- a/templates/bug_hunter.html
+++ b/templates/bug_hunter.html
@@ -7,7 +7,7 @@
 <p>At EdgeX Foundry, community means everything.  We would not be where we are today if it wasn't for our incredible community of volunteers like you.  Once again, thank you so much for all the hard work you have done for the project and our community.</p>
 
 <div style="background-color: #f1f0f2; padding: 10px 20px;">
-<p>Your contribution PRs:</p>
+<p>Your contribution PRs ({{count}}):</p>
 <ul class="prs" style="list-style: none; padding-left:0">
     {{#counted_prs}}
     <li style="margin: 10px 0; color:#85082a; font-size: 14px;"><img class="icon" width="16" height="16" src="https://raw.githubusercontent.com/edgexfoundry/edgex-dev-badge/templates/images/code-branch-icon.png" /> {{.}}</li>

--- a/templates/first_time_committer.html
+++ b/templates/first_time_committer.html
@@ -7,7 +7,7 @@
 <p>At EdgeX Foundry, community means everything.  We would not be where we are today if it wasn't for our incredible community of volunteers like you.  Once again, thank you so much for your first contribution.  We look forward to your future contributions and hope to see your continued active participation in our community.</p>
 
 <div style="background-color: #f1f0f2; padding: 10px 20px;">
-<p>Your contribution PR(s):</p>
+<p>Your contribution PRs ({{count}}):</p>
 <ul class="prs" style="list-style: none; padding-left:0">
     {{#counted_prs}}
     <li style="margin: 10px 0; color:#85082a; font-size: 14px;"><img class="icon" width="16" height="16" src="https://raw.githubusercontent.com/edgexfoundry/edgex-dev-badge/templates/images/code-branch-icon.png" /> {{.}}</li>


### PR DESCRIPTION
We now do the following for the Credly implementation:

- Create CSV file with winners if any, in the specified Credly format
- Archive CSV file to Jenkins
- Send admin email with winners and easy link to the CSV file

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>